### PR TITLE
Load entries back from firebase per week

### DIFF
--- a/src/components/AppMain.vue
+++ b/src/components/AppMain.vue
@@ -40,6 +40,7 @@ export default {
       for (let i = 0; i < this.daysPerWeek; i += 1) {
         weekdays.push(initialWeekday.clone().add(i, 'days'));
       }
+      this.$store.dispatch('loadWeekEntries', { start: weekdays[0], end: weekdays[this.daysPerWeek - 1] });
       return weekdays;
     },
   },

--- a/src/service/index.js
+++ b/src/service/index.js
@@ -1,4 +1,5 @@
 import { initializeApp, auth, database } from 'firebase';
+import moment from 'moment';
 import store from '../store';
 
 const SETTINGS = {
@@ -17,14 +18,25 @@ class Service {
       google: new auth.GoogleAuthProvider(),
     };
 
+    this.queue = [];
+
     auth().onAuthStateChanged((user) => {
       if (user) {
         store.dispatch('login', user);
         this.userKey = user.uid;
         this.dbRef = database().ref(this.userKey);
+        this.runQueue();
       } else {
         store.dispatch('logout');
+        this.userKey = undefined;
+        this.dbRef = undefined;
       }
+    });
+  }
+
+  runQueue() {
+    this.queue.forEach((e) => {
+      e.fn(...e.args);
     });
   }
 
@@ -36,13 +48,22 @@ class Service {
     return auth().signOut();
   }
 
-  serializeEntry(entry) { //eslint-disable-line
+  static serializeEntry(entry) { //eslint-disable-line
     return {
       ...entry,
       start: entry.start.toISOString(),
       end: entry.end.toISOString(),
     };
   }
+
+  static deserializeEntry(entry) {
+    return {
+      ...entry,
+      start: moment(entry.start),
+      end: moment(entry.end),
+    };
+  }
+
   /**
    * Adds a timeentry to the user spaced database in firebase
    * @param {timeentry} entry
@@ -54,7 +75,7 @@ class Service {
       key: entryKey,
     };
     const updates = {};
-    updates[`entries/${entryKey}`] = this.serializeEntry(payload);
+    updates[`entries/${entryKey}`] = Service.serializeEntry(payload);
     return this.dbRef.update(updates)
       .then(() => payload);
   }
@@ -66,8 +87,30 @@ class Service {
     return this.dbRef.child(`entries/${key}`).remove();
   }
 
-  loadEntriesForDay(day) {
-
+  /**
+   * Load Entries from firebase or from the @todo cache
+   * Dispatches `populateEntries` to store
+   * @param {moment} start
+   * @param {moment} end
+   */
+  loadEntries(start, end) {
+    if (!this.userKey) {
+      this.queue.push({ fn: this.loadEntries.bind(this), args: [start, end] });
+      return;
+    }
+    this.dbRef
+      .child('entries')
+      .orderByChild('start')
+      .startAt(start.toISOString())
+      .endAt(end.toISOString())
+      .once('value')
+      .then((snapshot) => {
+        // merge to array
+        const snapshotValue = snapshot.val();
+        return Object.keys(snapshotValue).map(key => snapshotValue[key]);
+      })
+      .then(entries => entries.map(entry => Service.deserializeEntry(entry)))
+      .then(entries => store.dispatch('populateEntries', entries));
   }
 }
 

--- a/src/service/index.js
+++ b/src/service/index.js
@@ -38,6 +38,7 @@ class Service {
     this.queue.forEach((e) => {
       e.fn(...e.args);
     });
+    this.queue = [];
   }
 
   login() {

--- a/src/store/modules/entries.js
+++ b/src/store/modules/entries.js
@@ -18,8 +18,14 @@ const getters = {
 
 // actions
 const actions = {
-  populateEntries({ commit }, entries) {
-    commit(types.POPULATE_ENTRIES, entries);
+  loadWeekEntries(_, { start, end }) {
+    Service.loadEntries(start, end);
+  },
+
+  populateEntries({ commit, state }, entries) { // eslint-disable-line
+    const entriesToAdd = entries
+    .filter(({ key }) => !state.entries.some(e => e.key === key));
+    commit(types.POPULATE_ENTRIES, entriesToAdd);
   },
 
   addEntry({ commit }, entry) {


### PR DESCRIPTION
Fixes #11 

Load Firebase entries for user. 
Use a queue to apply pulls when authorization is complete. 

Firebase entry configuration has index now set to start property for faster querying.